### PR TITLE
Improve usability of autotests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Download the latest armbian image for your board(s). We recommend to use .torren
 
 Put the SDcard into your device, power it up and let it sit for 1-2 minutes, to do the standard initial setup.
 
+Note: if you are connected with Wi-Fi only, remember to only set one network with NetworkManager. Otherwise the test will delete all saved networks. 
+
 ## Prepare your system
 
 1. Go to a folder where you want to store it. The following command will create a folder called 'autotests'. Clone the sources from Github and open the folder autotests:

--- a/go.sh
+++ b/go.sh
@@ -10,7 +10,7 @@
 #
 
 
-sudo apt install -y -qq jq expect sshpass nmap iperf3 &>/dev/null
+sudo apt install -y -qq jq expect sshpass nmap iperf3 netcat &>/dev/null
 
 
 #

--- a/go.sh
+++ b/go.sh
@@ -10,7 +10,7 @@
 #
 
 
-sudo apt install -y -qq jq expect sshpass nmap iperf3 netcat &>/dev/null
+sudo apt install -y -qq jq expect sshpass nmap iperf3 netcat curl bc &>/dev/null
 
 
 #

--- a/go.sh
+++ b/go.sh
@@ -120,6 +120,30 @@ echo "LOCALREPO=$LOCALREPO"
 
 echo ""
 
+#
+# Handle expert options (hidden to the user)
+#
+
+case $REGIONAL_MIRROR in
+	china)
+		[[ -z $GITHUB_MIRROR ]] && GITHUB_MIRROR=fastgit
+		;;
+	*)
+		;;
+esac
+
+case $GITHUB_MIRROR in
+	fastgit)
+		GITHUB_SOURCE='https://hub.fastgit.org/'
+		;;
+	cnpmjs)
+		GITHUB_SOURCE='https://github.com.cnpmjs.org/'
+		;;
+	*)
+		GITHUB_SOURCE='https://github.com/'
+		;;
+esac
+
 # cycle test cases and make a header row
 #
 # when DRY_RUN is set we cycle over test to basic information about tests, but do not run them
@@ -163,7 +187,7 @@ HEAD_HTML="<html>\n<head>\n<style type=\"text/css\">
 \n</style>\n<meta charset=\"UTF-8\">\n</head>\n<body><h1>Report ${REPORT_HTML}</h1>\
 \n<table class=\"TFtable\" cellspacing=0 width=100% border=0>
 \n<tr><td align=right rowspan=2>\
-<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/hashtag.png>\
+<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/hashtag.png>\
 </td><td align=center colspan=2>Board</td>\n"
 
 HEADER_HTML="${HEAD_HTML}${HEADER_HTML}</tr>\

--- a/init/0000-armbian-first-login.bash
+++ b/init/0000-armbian-first-login.bash
@@ -55,10 +55,12 @@ display_alert "Updating packages" "apt update only"
 remote_exec "chsh -s /bin/bash; apt -y purge armbian-config; apt update" "-t" "10m" &>/dev/null
 display_alert "Installing stress, armbian-config, bluez-tools, iozone3 and sbc-bench" "test dependencies"
 remote_exec "apt -qq -y install jq stress armbian-config bluez bluez-tools iozone3" "-t" "10m" &>/dev/null
-remote_exec "wget -q -O /usr/local/bin/sbc-bench https://raw.githubusercontent.com/ThomasKaiser/sbc-bench/master/sbc-bench.sh; chmod +x /usr/local/bin/sbc-bench" "-t" "10m" &>/dev/null
+remote_exec "wget -q -O /usr/local/bin/sbc-bench ${GITHUB_SOURCE}ThomasKaiser/sbc-bench/raw/master/sbc-bench.sh; chmod +x /usr/local/bin/sbc-bench" "-t" "10m" &>/dev/null
 
 # we will not wait for ideal load since load itself is more important than numbers
 remote_exec "sed -i \"s/\tCheckLoad/\t#CheckLoad/\" /usr/local/bin/sbc-bench"
+# also patch GitHub urls
+remote_exec "sed -i \"s|https://github.com/|${GITHUB_SOURCE}|g\" /usr/local/bin/sbc-bench"
 else
 remote_exec "dpkg --configure -a --force-confold" "-t" "10m" &>/dev/null
 fi

--- a/tests/0008-connect-wireless-devices-on-2.4Ghz.bash
+++ b/tests/0008-connect-wireless-devices-on-2.4Ghz.bash
@@ -3,7 +3,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="2.4Ghz"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/wifi.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/wifi.png>"
 TEST_SKIP="true"
 [[ $DRY_RUN == true ]] && return 0
 

--- a/tests/0013-iperf-on-all-wired-interfaces.bash
+++ b/tests/0013-iperf-on-all-wired-interfaces.bash
@@ -2,7 +2,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="Lan"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/lan.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/lan.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 display_alert "$(basename $BASH_SOURCE)" "$(date  +%R:%S)" "info"

--- a/tests/0014-iperf-on-all-wireless-interfaces.bash
+++ b/tests/0014-iperf-on-all-wireless-interfaces.bash
@@ -2,7 +2,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="2.4Ghz"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/wifi.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/wifi.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 display_alert "$(basename $BASH_SOURCE)" "$(date  +%R:%S)" "info"

--- a/tests/0015-connect-wireless-devices-on-5.0Ghz.bash
+++ b/tests/0015-connect-wireless-devices-on-5.0Ghz.bash
@@ -3,7 +3,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="5Ghz"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/wifi.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/wifi.png>"
 TEST_SKIP="true"
 [[ $DRY_RUN == true ]] && return 0
 

--- a/tests/0017-iperf-on-all-wireless-interfaces.bash
+++ b/tests/0017-iperf-on-all-wireless-interfaces.bash
@@ -13,5 +13,5 @@ readarray -t array < <(get_device "^[wr].*" "ip")
 if [[ "$FREQ5GHZ" -gt 1 ]]; then
 source $SRC/tests/include/iperf-on-all-interfaces.include
 else
-TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/na.png>"
+TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/na.png>"
 fi

--- a/tests/0018-io-tests-memory.bash
+++ b/tests/0018-io-tests-memory.bash
@@ -2,7 +2,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="memory"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/memory.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/memory.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 display_alert "$(basename $BASH_SOURCE)" "$(date  +%R:%S)" "info"
@@ -37,14 +37,14 @@ if [[ "$r" -le "${SBCBENCHPASS}" ]]; then
 			display_alert "Tiny memory bench" "Copy: $MEMCPY - Set: $MEMSET MB/s" "info"
 		else
 			display_alert "SBC bench not finished in time" "" "err"
-			TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/error.png>"
+			TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/error.png>"
 			MEMCPY=$TEST_OUTPUT
 			MEMSET=$TEST_OUTPUT
 			unset GETTEMP THROTTLING AES128 AES256 SBCBENCHURL
 			display_alert "Tiny memory bench" "No data" "wrn"
 		fi
 else
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/na.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/na.png>"
 fi
 
 

--- a/tests/0019-io-tests-drive.bash
+++ b/tests/0019-io-tests-drive.bash
@@ -2,7 +2,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="storage"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/storage.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/storage.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 display_alert "$(basename $BASH_SOURCE)" "$(date  +%R:%S)" "info"

--- a/tests/0100-openssl-benchmark.bash
+++ b/tests/0100-openssl-benchmark.bash
@@ -2,7 +2,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="AES-128"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/ssl.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/ssl.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 display_alert "$(basename $BASH_SOURCE)" "${BOARD_NAME} @ $(mask_ip "$USER_HOST")" "info"
@@ -14,7 +14,7 @@ if [[ "$r" -le "${SBCBENCHPASS}" && -n "${AES128}" ]]; then
 	
 	else
 
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/na.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/na.png>"
 	display_alert "OpenSSL bench" "No data" "wrn"
 
 fi

--- a/tests/0101-openssl-benchmark.bash
+++ b/tests/0101-openssl-benchmark.bash
@@ -2,7 +2,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="AES-256"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/ssl.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/ssl.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 display_alert "$(basename $BASH_SOURCE)" "${BOARD_NAME} @ $(mask_ip "$USER_HOST")" "info"
@@ -14,7 +14,7 @@ if [[ "$r" -le "${SBCBENCHPASS}" && -n "${AES128}" ]]; then
 
 	else
 
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/na.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/na.png>"
 	display_alert "OpenSSL bench" "No data" "wrn"
 
 fi

--- a/tests/0109-temp.bash
+++ b/tests/0109-temp.bash
@@ -2,7 +2,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="Temp"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/temp.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/temp.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 display_alert "$(basename $BASH_SOURCE)" "$(date  +%R:%S)" "info"
@@ -10,6 +10,6 @@ display_alert "$(basename $BASH_SOURCE)" "$(date  +%R:%S)" "info"
 if [[ -n ${GETTEMP} && "$r" -le "${SBCBENCHPASS}" ]]; then
 	TEST_OUTPUT="${GETTEMP}"
 else
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/na.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/na.png>"
 	display_alert "Board temperature" "No data" "wrn"
 fi

--- a/tests/0110-dvfs.bash
+++ b/tests/0110-dvfs.bash
@@ -2,7 +2,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="DVFS"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/dvfs.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/dvfs.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 display_alert "$(basename $BASH_SOURCE)" "$(date  +%R:%S)" "info"

--- a/tests/0111-bluetoth.bash
+++ b/tests/0111-bluetoth.bash
@@ -2,7 +2,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="BT"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/bluetooth.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/bluetooth.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 unset resoult
@@ -17,7 +17,7 @@ fi
 
 if [[ -n $resoult ]]; then 
 	display_alert "Bluetooth ping to your test device was succesfull" "$resoult" "info"
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/checked.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/checked.png>"
 	else
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/na.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/na.png>"
 fi

--- a/tests/0112-sbc-bench-url.bash
+++ b/tests/0112-sbc-bench-url.bash
@@ -2,13 +2,13 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="Report"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/link.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/link.png>"
 [[ $DRY_RUN == true ]] && return 0
 display_alert "$(basename $BASH_SOURCE)" "$(date  +%R:%S)" "info"
 
 if [[ -n ${SBCBENCHURL} && "$r" -le "${SBCBENCHPASS}" ]]; then
-	TEST_OUTPUT="<a tarbet=_blank href=${SBCBENCHURL}><img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/link.png></a>"
+	TEST_OUTPUT="<a tarbet=_blank href=${SBCBENCHURL}><img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/link.png></a>"
 else
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/na.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/na.png>"
 	display_alert "SBC-bench URL" "No data" "wrn"
 fi

--- a/tests/0115-throttling-detection.bash
+++ b/tests/0115-throttling-detection.bash
@@ -2,13 +2,13 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="Throttling"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/fire.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/fire.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 display_alert "$(basename $BASH_SOURCE)" "$(date  +%R:%S)" "info"
 
 if [[ "$r" -le "${SBCBENCHPASS}" && -n "${THROTTLING}" ]]; then
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/exclamation.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/exclamation.png>"
 	else
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/na.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/na.png>"
 fi

--- a/tests/0119-7-zip-benchmark.bash
+++ b/tests/0119-7-zip-benchmark.bash
@@ -2,7 +2,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="7z bench"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/7zip.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/7zip.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 display_alert "$(basename $BASH_SOURCE)" "${BOARD_NAME} @ $(mask_ip "$USER_HOST")" "info"
@@ -11,6 +11,6 @@ display_alert "7z bench" "${TEST_OUTPUT}" "info"
 if [[ "$r" -le "${SBCBENCHPASS}" && -n "${SEVENZIP}" ]]; then
 	TEST_OUTPUT=${SEVENZIP}
 else
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/na.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/na.png>"
 	display_alert "7z bench" "No data" "wrn"
 fi

--- a/tests/8500-install-kernel-sources.bash.disabled
+++ b/tests/8500-install-kernel-sources.bash.disabled
@@ -2,7 +2,7 @@
 source $SRC/lib/functions.sh
 
 TEST_TITLE="Sources"
-TEST_ICON="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/code.png>"
+TEST_ICON="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/code.png>"
 [[ $DRY_RUN == true ]] && return 0
 
 display_alert "$(basename $BASH_SOURCE)" "${BOARD_NAME}" "info"
@@ -42,10 +42,10 @@ fi
 
 if [[ ${TEST_RESOULTS} == "OK" ]]; then
 	display_alert "Correct sources were installed" "" "info"
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/checked.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/checked.png>"
 	else
 	display_alert "Wrong sources $(remote_exec "ls -1 /usr/src/ | grep linux-source") were installed" "" "err"
-	TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/error.png>"
+	TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/error.png>"
 fi
 
 # clean after

--- a/tests/include/iperf-on-all-interfaces.include
+++ b/tests/include/iperf-on-all-interfaces.include
@@ -26,7 +26,7 @@ do
 	TEST_OUTPUT+="<small>$(echo $device | cut -d \( -f2 | cut -d \) -f1)<br></small> ${speed_from}${speed_to}<br>"
 
 done
-[[ ${#array[@]} -eq 0 ]] && TEST_OUTPUT="<img width=20 src=https://raw.githubusercontent.com/armbian/autotests/master/icons/na.png>"
+[[ ${#array[@]} -eq 0 ]] && TEST_OUTPUT="<img width=20 src=${GITHUB_SOURCE}armbian/autotests/raw/master/icons/na.png>"
 sleep 1
 remote_exec "pkill -F /var/run/iperf3"
 rm -f $SRC/logs/armbian-iperf


### PR DESCRIPTION
* Add missing host dependencies that are not part of a default* Debian install. (default means using Debian installer without selecting `standard system utilities`)
* Add `REGION_MIRROR` option to speed up resource download. Also patches `sbc-bench` to use the same mirror.
* Add a note in README.md to use one Wi-Fi network only.

<details>
  <summary>Tested on trunk build of radxa-zero bullseye minimal.</summary>

    Command line: setting REGIONAL_MIRROR to china
    Display config options:

    PASSES=5
    SBCBENCHPASS=5
    COMPARE=no
    PARALLEL=no
    FRESH=yes
    BSPSWITCH=no
    EMULATED=
    LOCALREPO=apt.armbian.com

    Preparing tests
    - Lan
    - 2.4Ghz
    - 5Ghz
    - memory
    - storage
    - AES-128
    - AES-256
    - Temp
    - DVFS
    - BT
    - Report
    - Throttling
    - 7z bench

    [ o.k. ] 0. Trying [ 19:54:04 - 31.111 ]
    [ .... ] Run apt fixes just to make sure [ apt-get -f install ]
    [ .... ] Updating packages [ apt update only ]
    [ .... ] Installing stress, armbian-config, bluez-tools, iozone3 and sbc-bench [ test dependencies ]
    [ o.k. ] Radxa Zero Linux 5.10.84-meson64  bullseye user-built [ 19:55:01 - 31.111 Uptime: 25 min ]
    [ o.k. ] Diff to previous build [ added or removed ]

    [ o.k. ] Host 31.111 found [ Run 1 out of 5 ]
    [ o.k. ] Radxa Zero [ Linux 5.10.84-meson64 ]
    [ o.k. ] 0002-update-and-upgrade.bash [ 19:55:26 ]
    [ o.k. ] Updating and upgrading [ 0 packages ]
    [ o.k. ] 0008-connect-wireless-devices-on-2.4Ghz.bash [ 19:56:02 ]
    [ o.k. ] Connecting ...  [ wlan0 ]
    [ o.k. ] 0013-iperf-on-all-wired-interfaces.bash [ 19:56:27 ]
    [ o.k. ] 0014-iperf-on-all-wireless-interfaces.bash [ 19:56:40 ]
    [ o.k. ] ... "Broadcom Wi-Fi" wifi (brcmfmac) [  23 MBits/s ]
    [ o.k. ] 0015-connect-wireless-devices-on-5.0Ghz.bash [ 19:57:04 ]
    [ o.k. ] Connecting ...  [ wlan0 ]
    [ o.k. ] 0017-iperf-on-all-wireless-interfaces.bash [ 19:57:27 ]
    [ o.k. ] ... "Broadcom Wi-Fi" wifi (brcmfmac) [  21 MBits/s ]
    [ o.k. ] 0018-io-tests-memory.bash [ 19:57:52 ]
    [ o.k. ] This will take some time ... [ Please wait! ]
    [ o.k. ] Tiny memory bench [ Copy: 1406 - Set: 3377 MB/s ]
    [ o.k. ] 0019-io-tests-drive.bash [ 20:17:45 ]
    [ o.k. ] Max random roofs throughput on 16Mb files [ Read: 1075 MBits/s - Write: 24 MBits/s ]
    [ o.k. ] 0100-openssl-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] OpenSSL bench [ AES-128 16byte: 118275 ]
    [ o.k. ] 0101-openssl-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] OpenSSL bench [ AES-256 16byte 118275 ]
    [ o.k. ] 0109-temp.bash [ 20:18:21 ]
    [ o.k. ] 0110-dvfs.bash [ 20:18:28 ]
    [ o.k. ] ... DVFS works [ 100 - 1800 Mhz ]
    [ o.k. ] 0111-bluetoth.bash [ Radxa Zero ]
    [ o.k. ] 0112-sbc-bench-url.bash [ 20:18:52 ]
    [ o.k. ] 0115-throttling-detection.bash [ 20:18:59 ]
    [ o.k. ] 0119-7-zip-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] 7z bench 
    [ o.k. ] 9003-u-boot-upgrade.bash [ 20:19:20 ]
    [ o.k. ] Write u-boot to /dev/mmcblk0 with UUID=a45cf901-bca2-49b5-9774-b5af3665b56b [ 20:19:23 ]
    [ o.k. ] 9999-reboot.bash [ 20:19:31 ]
    [ o.k. ] Rebooting in 3 seconds [ Radxa Zero ]
    [ o.k. ] Ping 192.168.31.111 failed 1 [ 20:19:55 ]
    [ o.k. ] Ping 192.168.31.111 failed 2 [ 20:20:08 ]
    [ o.k. ] Host 31.111 found [ Run 2 out of 5 ]
    [ o.k. ] Radxa Zero [ Linux 5.10.84-meson64 ]
    [ o.k. ] 0002-update-and-upgrade.bash [ 20:20:42 ]
    [ o.k. ] Updating and upgrading [ 0 packages ]
    [ o.k. ] 0008-connect-wireless-devices-on-2.4Ghz.bash [ 20:21:09 ]
    [ o.k. ] Connecting ...  [ wlan0 ]
    [ o.k. ] 0013-iperf-on-all-wired-interfaces.bash [ 20:21:36 ]
    [ o.k. ] 0014-iperf-on-all-wireless-interfaces.bash [ 20:21:49 ]
    [ o.k. ] ... "Broadcom Wi-Fi" wifi (brcmfmac) [  23 MBits/s ]
    [ o.k. ] 0015-connect-wireless-devices-on-5.0Ghz.bash [ 20:22:15 ]
    [ o.k. ] Connecting ...  [ wlan0 ]
    [ o.k. ] 0017-iperf-on-all-wireless-interfaces.bash [ 20:22:39 ]
    [ o.k. ] ... "Broadcom Wi-Fi" wifi (brcmfmac) [  20 MBits/s ]
    [ o.k. ] 0018-io-tests-memory.bash [ 20:23:03 ]
    [ o.k. ] This will take some time ... [ Please wait! ]
    [ o.k. ] Tiny memory bench [ Copy: 1403 - Set: 3379 MB/s ]
    [ o.k. ] 0019-io-tests-drive.bash [ 20:42:52 ]
    [ o.k. ] Max random roofs throughput on 16Mb files [ Read: 1075 MBits/s - Write: 24 MBits/s ]
    [ o.k. ] 0100-openssl-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] OpenSSL bench [ AES-128 16byte: 104955 ]
    [ o.k. ] 0101-openssl-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] OpenSSL bench [ AES-256 16byte 104955 ]
    [ o.k. ] 0109-temp.bash [ 20:43:27 ]
    [ o.k. ] 0110-dvfs.bash [ 20:43:35 ]
    [ o.k. ] ... DVFS works [ 100 - 1800 Mhz ]
    [ o.k. ] 0111-bluetoth.bash [ Radxa Zero ]
    [ o.k. ] 0112-sbc-bench-url.bash [ 20:43:58 ]
    [ o.k. ] 0115-throttling-detection.bash [ 20:44:06 ]
    [ o.k. ] 0119-7-zip-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] 7z bench 
    [ o.k. ] 9003-u-boot-upgrade.bash [ 20:44:29 ]
    [ o.k. ] Write u-boot to /dev/mmcblk0 with UUID=a45cf901-bca2-49b5-9774-b5af3665b56b [ 20:44:32 ]
    [ o.k. ] 9999-reboot.bash [ 20:44:39 ]
    [ o.k. ] Rebooting in 3 seconds [ Radxa Zero ]
    [ o.k. ] Ping 192.168.31.111 failed 1 [ 20:45:03 ]
    [ o.k. ] Host 31.111 found [ Run 3 out of 5 ]
    [ o.k. ] Radxa Zero [ Linux 5.10.84-meson64 ]
    [ o.k. ] 0002-update-and-upgrade.bash [ 20:45:39 ]
    [ o.k. ] Updating and upgrading [ 0 packages ]
    [ o.k. ] 0008-connect-wireless-devices-on-2.4Ghz.bash [ 20:46:02 ]
    [ o.k. ] Connecting ...  [ wlan0 ]
    [ o.k. ] 0013-iperf-on-all-wired-interfaces.bash [ 20:46:29 ]
    [ o.k. ] 0014-iperf-on-all-wireless-interfaces.bash [ 20:46:42 ]
    [ o.k. ] ... "Broadcom Wi-Fi" wifi (brcmfmac) [  18 MBits/s ]
    [ o.k. ] 0015-connect-wireless-devices-on-5.0Ghz.bash [ 20:47:06 ]
    [ o.k. ] Connecting ...  [ wlan0 ]
    [ o.k. ] 0017-iperf-on-all-wireless-interfaces.bash [ 20:47:30 ]
    [ o.k. ] ... "Broadcom Wi-Fi" wifi (brcmfmac) [  22 MBits/s ]
    [ o.k. ] 0018-io-tests-memory.bash [ 20:47:54 ]
    [ o.k. ] This will take some time ... [ Please wait! ]
    [ o.k. ] Tiny memory bench [ Copy: 1405 - Set: 3378 MB/s ]
    [ o.k. ] 0019-io-tests-drive.bash [ 21:07:39 ]
    [ o.k. ] Max random roofs throughput on 16Mb files [ Read: 1074 MBits/s - Write: 24 MBits/s ]
    [ o.k. ] 0100-openssl-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] OpenSSL bench [ AES-128 16byte: 117955 ]
    [ o.k. ] 0101-openssl-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] OpenSSL bench [ AES-256 16byte 117955 ]
    [ o.k. ] 0109-temp.bash [ 21:08:14 ]
    [ o.k. ] 0110-dvfs.bash [ 21:08:21 ]
    [ o.k. ] ... DVFS works [ 100 - 1800 Mhz ]
    [ o.k. ] 0111-bluetoth.bash [ Radxa Zero ]
    [ o.k. ] 0112-sbc-bench-url.bash [ 21:08:45 ]
    [ o.k. ] 0115-throttling-detection.bash [ 21:08:53 ]
    [ o.k. ] 0119-7-zip-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] 7z bench 
    [ o.k. ] 9003-u-boot-upgrade.bash [ 21:09:14 ]
    [ o.k. ] Write u-boot to /dev/mmcblk2 with UUID=a45cf901-bca2-49b5-9774-b5af3665b56b [ 21:09:17 ]
    [ o.k. ] 9999-reboot.bash [ 21:09:24 ]
    [ o.k. ] Rebooting in 3 seconds [ Radxa Zero ]
    [ o.k. ] Ping 192.168.31.111 failed 1 [ 21:09:48 ]
    [ o.k. ] Ping 192.168.31.111 failed 2 [ 21:10:08 ]
    [ o.k. ] Host 31.111 found [ Run 4 out of 5 ]
    [ o.k. ] Radxa Zero [ Linux 5.10.84-meson64 ]
    [ o.k. ] 0002-update-and-upgrade.bash [ 21:10:42 ]
    [ o.k. ] Updating and upgrading [ 0 packages ]
    [ o.k. ] 0008-connect-wireless-devices-on-2.4Ghz.bash [ 21:11:05 ]
    [ o.k. ] Connecting ...  [ wlan0 ]
    [ o.k. ] 0013-iperf-on-all-wired-interfaces.bash [ 21:11:30 ]
    [ o.k. ] 0014-iperf-on-all-wireless-interfaces.bash [ 21:11:42 ]
    [ o.k. ] ... "Broadcom Wi-Fi" wifi (brcmfmac) [  21 MBits/s ]
    [ o.k. ] 0015-connect-wireless-devices-on-5.0Ghz.bash [ 21:12:06 ]
    [ o.k. ] Connecting ...  [ wlan0 ]
    [ o.k. ] 0017-iperf-on-all-wireless-interfaces.bash [ 21:12:28 ]
    [ o.k. ] ... "Broadcom Wi-Fi" wifi (brcmfmac) [  22 MBits/s ]
    [ o.k. ] 0018-io-tests-memory.bash [ 21:12:52 ]
    [ o.k. ] This will take some time ... [ Please wait! ]
    [ o.k. ] Tiny memory bench [ Copy: 1400 - Set: 3378 MB/s ]
    [ o.k. ] 0019-io-tests-drive.bash [ 21:32:02 ]
    [ o.k. ] Max random roofs throughput on 16Mb files [ Read: 1068 MBits/s - Write: 25 MBits/s ]
    [ o.k. ] 0100-openssl-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] OpenSSL bench [ AES-128 16byte: 117768 ]
    [ o.k. ] 0101-openssl-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] OpenSSL bench [ AES-256 16byte 117768 ]
    [ o.k. ] 0109-temp.bash [ 21:32:37 ]
    [ o.k. ] 0110-dvfs.bash [ 21:32:44 ]
    [ o.k. ] ... DVFS works [ 100 - 1800 Mhz ]
    [ o.k. ] 0111-bluetoth.bash [ Radxa Zero ]
    [ o.k. ] 0112-sbc-bench-url.bash [ 21:33:08 ]
    [ o.k. ] 0115-throttling-detection.bash [ 21:33:15 ]
    [ o.k. ] 0119-7-zip-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] 7z bench 
    [ o.k. ] 9003-u-boot-upgrade.bash [ 21:33:36 ]
    [ o.k. ] Write u-boot to /dev/mmcblk2 with UUID=a45cf901-bca2-49b5-9774-b5af3665b56b [ 21:33:39 ]
    [ o.k. ] 9999-reboot.bash [ 21:33:46 ]
    [ o.k. ] Rebooting in 3 seconds [ Radxa Zero ]
    [ o.k. ] Ping 192.168.31.111 failed 1 [ 21:34:10 ]
    [ o.k. ] Host 31.111 found [ Run 5 out of 5 ]
    [ o.k. ] Radxa Zero [ Linux 5.10.84-meson64 ]
    [ o.k. ] 0002-update-and-upgrade.bash [ 21:34:46 ]
    [ o.k. ] Updating and upgrading [ 0 packages ]
    [ o.k. ] 0008-connect-wireless-devices-on-2.4Ghz.bash [ 21:35:18 ]
    [ o.k. ] Connecting ...  [ wlan0 ]
    [ o.k. ] 0013-iperf-on-all-wired-interfaces.bash [ 21:35:44 ]
    [ o.k. ] 0014-iperf-on-all-wireless-interfaces.bash [ 21:35:56 ]
    [ o.k. ] ... "Broadcom Wi-Fi" wifi (brcmfmac) [  28 MBits/s ]
    [ o.k. ] 0015-connect-wireless-devices-on-5.0Ghz.bash [ 21:36:20 ]
    [ o.k. ] Connecting ...  [ wlan0 ]
    [ o.k. ] 0017-iperf-on-all-wireless-interfaces.bash [ 21:36:42 ]
    [ o.k. ] ... "Broadcom Wi-Fi" wifi (brcmfmac) [  19 MBits/s ]
    [ o.k. ] 0018-io-tests-memory.bash [ 21:37:06 ]
    [ o.k. ] This will take some time ... [ Please wait! ]
    [ o.k. ] Tiny memory bench [ Copy: 1401 - Set: 3378 MB/s ]
    [ o.k. ] 0019-io-tests-drive.bash [ 21:56:49 ]
    [ o.k. ] Max random roofs throughput on 16Mb files [ Read: 1077 MBits/s - Write: 24 MBits/s ]
    [ o.k. ] 0100-openssl-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] OpenSSL bench [ AES-128 16byte: 104901 ]
    [ o.k. ] 0101-openssl-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] OpenSSL bench [ AES-256 16byte 104901 ]
    [ o.k. ] 0109-temp.bash [ 21:57:24 ]
    [ o.k. ] 0110-dvfs.bash [ 21:57:32 ]
    [ o.k. ] ... DVFS works [ 100 - 1800 Mhz ]
    [ o.k. ] 0111-bluetoth.bash [ Radxa Zero ]
    [ o.k. ] 0112-sbc-bench-url.bash [ 21:57:55 ]
    [ o.k. ] 0115-throttling-detection.bash [ 21:58:02 ]
    [ o.k. ] 0119-7-zip-benchmark.bash [ Radxa Zero @ 31.111 ]
    [ o.k. ] 7z bench 
    [ o.k. ] 9003-u-boot-upgrade.bash [ 21:58:23 ]
    [ o.k. ] Write u-boot to /dev/mmcblk0 with UUID=a45cf901-bca2-49b5-9774-b5af3665b56b [ 21:58:26 ]
    [ o.k. ] 9999-reboot.bash [ 21:58:33 ]
    [ o.k. ] Rebooting in 3 seconds [ Radxa Zero ]
    This whole procedure took 124 minutes.
</details>
